### PR TITLE
feat: add total count property to pagination processes and update pag…

### DIFF
--- a/libs/prisma/src/processes/pagination.process.ts
+++ b/libs/prisma/src/processes/pagination.process.ts
@@ -6,11 +6,15 @@ export class PrismaPaginationProcess
   extends PrismaProcess
   implements PaginationProcess
 {
+  total: number;
   params: IPaginationParam;
 
   async process() {
     const { page, limit } = this.params;
     const skip = (page - 1) * limit;
+
+    // Get total count
+    this.total = await this.getDelegate().count();
 
     this.result = await this.getDelegate().findMany({
       skip,

--- a/libs/skeleton/src/interfaces/controller/skeleton-crud.controller.interface.ts
+++ b/libs/skeleton/src/interfaces/controller/skeleton-crud.controller.interface.ts
@@ -1,7 +1,7 @@
 import { IPaginationParam } from '../pagination-param.interface';
 
 export interface ISkeletonPaginationController {
-  pagination(params: IPaginationParam);
+  pagination(params: IPaginationParam, res: any);
 }
 
 export interface ISkeletonListController {

--- a/libs/skeleton/src/processes/pagination.process.ts
+++ b/libs/skeleton/src/processes/pagination.process.ts
@@ -3,4 +3,5 @@ import { DefaultProcess } from './default.process';
 
 export class PaginationProcess extends DefaultProcess {
   params: IPaginationParam;
+  total: number;
 }

--- a/libs/typeorm/src/processes/pagination.process.ts
+++ b/libs/typeorm/src/processes/pagination.process.ts
@@ -6,11 +6,15 @@ export class TypeORMPaginationProcess<T>
   extends TypeORMProcess<T>
   implements PaginationProcess
 {
+  total: number;
   params: IPaginationParam;
 
   async process() {
     const { page, limit } = this.params;
     const skip = (page - 1) * limit;
+
+    // Get total count
+    this.total = await this.service.getRepository().count();
 
     this.result = await this.service.getRepository().find({
       skip,


### PR DESCRIPTION
This pull request introduces enhancements to the pagination process across Prisma, TypeORM, and Skeleton controllers. Key changes include adding a `total` property to track the total count of records, updating method signatures to support response headers, and ensuring the total count is included in HTTP headers for better client-side pagination handling.

### Enhancements to Pagination Process:

* **Prisma Pagination Process**:
  - Added a `total` property to `PrismaPaginationProcess` to store the total count of records. Updated the `process` method to calculate this count using `getDelegate().count()`.

* **TypeORM Pagination Process**:
  - Added a `total` property to `TypeORMPaginationProcess` to store the total count of records. Updated the `process` method to calculate this count using `service.getRepository().count()`.

### Updates to Skeleton Controller:

* **Pagination Method**:
  - Modified the `pagination` method in `SkeletonCRUDController` to accept a `res` parameter for setting the `X-Total-Count` header. This ensures the total count is included in HTTP headers for both Express and Fastify frameworks.
  - Updated the `CustomCRUDController` to propagate the `res` parameter when calling the `pagination` method.

* **Interface Changes**:
  - Updated the `ISkeletonPaginationController` interface to include the `res` parameter in the `pagination` method signature.

### Codebase Maintenance:

* **Imports Cleanup**:
  - Removed redundant imports of controller interfaces in `skeleton-crud.controller.ts` and reorganized imports for better readability.…ination controller methods